### PR TITLE
Include <cstdint> in lib/smtgcc.h

### DIFF
--- a/lib/smtgcc.h
+++ b/lib/smtgcc.h
@@ -2,6 +2,7 @@
 #define SMTGCC_H
 
 #include <array>
+#include <cstdint>
 #include <map>
 #include <optional>
 #include <set>


### PR DESCRIPTION
The header lib/smtgcc.h uses uint8_t and other types of fixed size but doesn't include \<cstdint\>. I wasn't able to compile smtgcc until I added this include.