### PR TITLE
Extend loop unrolling with one more loop case

### DIFF
--- a/lib/loop_unroll.cpp
+++ b/lib/loop_unroll.cpp
@@ -1,6 +1,6 @@
 // Unroll loops.
 //
-// Only very simple loops (consisting of 1 or 2 basic blocks) are handled.
+// Only very simple loops (consisting of 1, 2 or 3 basic blocks) are handled.
 
 #include <algorithm>
 #include <cassert>
@@ -8,6 +8,8 @@
 #include <set>
 
 #include "smtgcc.h"
+
+#include "stdio.h"
 
 using namespace std::string_literals;
 
@@ -338,6 +340,351 @@ void Unroller::unroll()
     }
 }
 
+class AdvancedUnroller
+{
+  Function *func;
+  Basic_block *loop_latch;
+  Basic_block *loop_exit;
+  Basic_block *loop_header;
+  Basic_block *loop_mid;
+  Basic_block *orig_loop_exit;
+  std::map<Instruction *, Instruction *> curr_inst;
+
+  std::vector<Basic_block *> loop_bbs;
+
+  void duplicate(Instruction *inst, Basic_block *bb);
+  Instruction *translate(Instruction *inst);
+  void ensure_lcssa(Instruction *inst);
+  void create_lcssa();
+
+public:
+  AdvancedUnroller(Basic_block *bb);
+  void unroll();
+};
+
+AdvancedUnroller::AdvancedUnroller(Basic_block *l)
+{
+  Basic_block *bb1 = l->preds[0];
+  Basic_block *bb2 = l->preds[1];
+  if (bb2->preds.size() != 1 || bb2->preds[0] != bb1)
+    {
+      std::swap(bb1, bb2);
+      assert(bb2->preds.size() == 1 && bb2->preds[0] == bb1);
+    }
+
+  loop_latch = l;
+  if (l->succs[0] == bb1)
+    orig_loop_exit = l->succs[1];
+  else
+    orig_loop_exit = l->succs[0];
+  loop_header = bb1;
+  loop_mid = bb2;
+
+  loop_bbs.push_back(loop_header);
+  loop_bbs.push_back(loop_mid);
+  loop_bbs.push_back(loop_latch);
+
+  func = l->func;
+}
+
+// Almost same code as Unroller::ensure_lcssa (loop_header -> loop_latch)
+void AdvancedUnroller::ensure_lcssa(Instruction *inst)
+{
+  std::vector<Instruction *> invalid_use;
+  for (auto use : inst->used_by)
+    {
+      if (use->bb == loop_exit && use->opcode == Op::PHI)
+	continue;
+      auto I = std::find(loop_bbs.begin(), loop_bbs.end(), use->bb);
+      if (I == loop_bbs.end())
+	invalid_use.push_back(use);
+    }
+
+  if (!invalid_use.empty())
+    {
+      Instruction *phi = loop_exit->build_phi_inst(inst->bitsize);
+      phi->add_phi_arg(inst, loop_latch);
+      while (!invalid_use.empty())
+	{
+	  Instruction *use = invalid_use.back();
+	  invalid_use.pop_back();
+	  inst->replace_use_with(use, phi);
+	}
+    }
+}
+
+// Same code as Unroller::create_lcssa
+void AdvancedUnroller::create_lcssa()
+{
+  for (auto bb : loop_bbs)
+    {
+      for (auto phi : bb->phis)
+	{
+	  ensure_lcssa(phi);
+	}
+      for (Instruction *inst = bb->first_inst; inst; inst = inst->next)
+	{
+	  ensure_lcssa(inst);
+	}
+    }
+}
+
+// Find an 'advanced loop' -- a loop that looks like this:
+//
+//      \|/
+//   +- HEAD<---+
+//   |   |      |
+//   |  MID     |
+//   |   |      |
+//   +->LATCH --+
+//       |
+//      exit
+//
+// Given a block L if these conditions hold, L is the latch of an advanced
+// loop:
+// 1 L has two predecessors H and M
+// 2 L has two successors
+// 3 H is the sole predecessor of M
+// 4 H is a successor of L
+// 5 M has exactly one successor
+Basic_block *find_advanced_loop(Function *func)
+{
+  for (auto l : func->bbs)
+    {
+      // Condition 1
+      if (l->preds.size() != 2)
+	continue;
+      // Condition 2
+      if (l->succs.size() != 2)
+	continue;
+      // Condition 3
+      Basic_block *h = l->preds[0];
+      Basic_block *m = l->preds[1];
+      if (m->preds.size() != 1 || m->preds[0] != h)
+	{
+	  std::swap(h, m);
+	  if (m->preds.size() != 1 || m->preds[0] != h)
+	    continue;
+	}
+      // Condition 4
+      if (h != l->succs[0] && h != l->succs[1])
+	continue;
+      // Condition 5
+      if (m->succs.size() != 1)
+	continue;
+
+      return l;
+    }
+  return nullptr;
+}
+
+Instruction *AdvancedUnroller::translate(Instruction *inst)
+{
+  auto I = curr_inst.find(inst);
+  if (I != curr_inst.end())
+    return I->second;
+  return inst;
+}
+
+// Same code as Unroller::duplicate
+void AdvancedUnroller::duplicate(Instruction *inst, Basic_block *bb)
+{
+  Instruction *new_inst = nullptr;
+  Inst_class iclass = inst->iclass();
+  switch (iclass)
+    {
+    case Inst_class::iunary:
+    case Inst_class::funary:
+      {
+	Instruction *arg = translate(inst->arguments[0]);
+	new_inst = bb->build_inst(inst->opcode, arg);
+      }
+      break;
+    case Inst_class::icomparison:
+    case Inst_class::fcomparison:
+    case Inst_class::ibinary:
+    case Inst_class::fbinary:
+    case Inst_class::conv:
+      {
+	Instruction *arg1 = translate(inst->arguments[0]);
+	Instruction *arg2 = translate(inst->arguments[1]);
+	new_inst = bb->build_inst(inst->opcode, arg1, arg2);
+      }
+      break;
+    case Inst_class::ternary:
+      {
+	Instruction *arg1 = translate(inst->arguments[0]);
+	Instruction *arg2 = translate(inst->arguments[1]);
+	Instruction *arg3 = translate(inst->arguments[2]);
+	new_inst = bb->build_inst(inst->opcode, arg1, arg2, arg3);
+      }
+      break;
+    default:
+      throw Not_implemented("unroller::duplicate: "s + inst->name());
+    }
+  assert(new_inst);
+  curr_inst[inst] = new_inst;
+}
+
+void AdvancedUnroller::unroll()
+{
+  // Add a new loop exit block that only have phi nodes. This is
+  // not necessary, but it makes it easier to verify that we
+  // create correct LCSSA.
+  {
+    loop_exit = func->build_bb();
+    loop_exit->build_br_inst(orig_loop_exit);
+    for (auto orig_phi : orig_loop_exit->phis)
+      {
+	Instruction *phi = loop_exit->build_phi_inst(orig_phi->bitsize);
+	Instruction *arg = orig_phi->get_phi_arg(loop_latch);
+	phi->add_phi_arg(arg, loop_latch);
+	orig_phi->remove_phi_arg(loop_latch);
+	orig_phi->add_phi_arg(phi, loop_exit);
+      }
+    assert(loop_latch->last_inst->opcode == Op::BR);
+    assert(loop_latch->last_inst->nof_args == 1);
+    Instruction *cond = loop_latch->last_inst->arguments[0];
+    Basic_block *true_bb = loop_latch->last_inst->u.br3.true_bb;
+    if (true_bb == orig_loop_exit)
+      true_bb = loop_exit;
+    else
+      assert(true_bb == loop_latch
+	     || true_bb == loop_header
+	     || true_bb == loop_mid);
+    Basic_block *false_bb = loop_latch->last_inst->u.br3.false_bb;
+    if (false_bb == orig_loop_exit)
+      false_bb = loop_exit;
+    else
+      assert(false_bb == loop_latch
+	     || false_bb == loop_header
+	     || false_bb == loop_mid);
+    destroy_instruction(loop_latch->last_inst);
+    loop_latch->build_br_inst(cond, true_bb, false_bb);
+  }
+
+  create_lcssa();
+
+  std::vector<Basic_block *> head_bbs;
+  std::vector<Basic_block *> mid_bbs;
+  std::vector<Basic_block *> latch_bbs;
+  // Note: unroll_limit-1 because we already have bbs for the first iteration
+  for (int i = 0; i < unroll_limit - 1; i++)
+    {
+      head_bbs.push_back(func->build_bb());
+      mid_bbs.push_back(func->build_bb());
+      latch_bbs.push_back(func->build_bb());
+    }
+  head_bbs.push_back(func->build_bb()); // One more block for UB
+
+  for (int i = 0; i < unroll_limit - 1; i++)
+    {
+      // Duplicate HEADER block
+      std::map<Instruction *, Instruction *> tmp_curr_inst;
+      for (auto phi : loop_header->phis)
+	{
+	  tmp_curr_inst[phi] = translate(phi->get_phi_arg(loop_latch));
+	}
+      for (auto [phi, translated_phi] : tmp_curr_inst)
+	{
+	  curr_inst[phi] = translated_phi;
+	}
+      for (Instruction *inst = loop_header->first_inst;
+	   inst;
+	   inst = inst->next)
+	{
+	  if (inst->opcode == Op::BR)
+	    {
+	      assert(inst->nof_args == 1);
+	      Instruction *arg = translate(inst->arguments[0]);
+	      Basic_block *true_bb = mid_bbs.at(i);
+	      Basic_block *false_bb = latch_bbs.at(i);
+	      if (inst->u.br3.true_bb == loop_latch)
+		std::swap(true_bb, false_bb);
+	      head_bbs.at(i)->build_br_inst(arg, true_bb, false_bb);
+	    }
+	  else
+	    duplicate(inst, head_bbs.at(i));
+	}
+
+      // Duplicate MID block
+      for (Instruction *inst = loop_mid->first_inst;
+	   inst;
+	   inst = inst->next)
+	{
+	  if (inst->opcode == Op::BR)
+	    {
+	      assert(inst->nof_args == 0);
+	      mid_bbs.at(i)->build_br_inst(latch_bbs.at(i));
+	    }
+	  else
+	    duplicate(inst, mid_bbs.at(i));
+	}
+
+      // Duplicate LATCH block
+      for (auto phi : loop_latch->phis)
+	{
+	  Instruction *arg_if = translate(phi->get_phi_arg(loop_header));
+	  Instruction *arg_then = translate(phi->get_phi_arg(loop_mid));
+	  Instruction *new_phi = latch_bbs.at(i)->build_phi_inst(phi->bitsize);
+	  new_phi->add_phi_arg(arg_if, head_bbs.at(i));
+	  new_phi->add_phi_arg(arg_then, mid_bbs.at(i));
+	  curr_inst[phi] = new_phi;
+	}
+      for (Instruction *inst = loop_latch->first_inst;
+	   inst;
+	   inst = inst->next)
+	{
+	  if (inst->opcode == Op::BR)
+	    {
+	      assert(inst->nof_args == 1);
+	      Instruction *arg = translate(inst->arguments[0]);
+	      Basic_block *true_bb = head_bbs.at(i + 1);
+	      Basic_block *false_bb = loop_exit;
+	      if (inst->u.br3.true_bb == loop_exit)
+		std::swap(true_bb, false_bb);
+	      latch_bbs.at(i)->build_br_inst(arg, true_bb, false_bb);
+	      for (auto phi : loop_exit->phis)
+		{
+		  Instruction *phi_arg = phi->get_phi_arg(loop_latch);
+		  phi->add_phi_arg(translate(phi_arg), latch_bbs.at(i));
+		}
+	    }
+	  else
+	    duplicate(inst, latch_bbs.at(i));
+	}
+    }
+
+  // The last block is for cases the program loops more than our unroll limit.
+  // This makes our analysis invalid, so we mark this as UB.
+  Basic_block *last_bb = head_bbs.at(unroll_limit - 1);
+  last_bb->build_inst(Op::UB, last_bb->value_inst(1, 1));
+  last_bb->build_br_inst(loop_exit);
+  for (auto phi : loop_exit->phis)
+    {
+      phi->add_phi_arg(last_bb->value_inst(0, phi->bitsize), last_bb);
+    }
+
+  // Update the original loop to only do the first iteration.
+  for (auto phi : loop_header->phis)
+    {
+      phi->remove_phi_arg(loop_latch);
+    }
+  Instruction *cond = loop_latch->last_inst->arguments[0];
+  Basic_block *true_bb = loop_latch->last_inst->u.br3.true_bb;
+  Basic_block *false_bb = loop_latch->last_inst->u.br3.false_bb;
+  if (true_bb == loop_header)
+    true_bb = head_bbs.at(0);
+  else
+    assert(true_bb == loop_exit);
+  if (false_bb == loop_header)
+    false_bb = head_bbs.at(0);
+  else
+    assert(false_bb == loop_exit);
+  destroy_instruction(loop_latch->last_inst);
+  loop_latch->build_br_inst(cond, true_bb, false_bb);
+}
+
 } // end anonymous namespace
 
 bool loop_unroll(Function *func)
@@ -347,6 +694,13 @@ bool loop_unroll(Function *func)
   while ((bb = find_simple_loop(func)))
     {
       Unroller unroller(bb);
+      unroller.unroll();
+      reverse_post_order(func);
+      unrolled = true;
+    }
+  while ((bb = find_advanced_loop(func)))
+    {
+      AdvancedUnroller unroller(bb);
       unroller.unroll();
       reverse_post_order(func);
       unrolled = true;


### PR DESCRIPTION
This patch extends loop unroller to also handle this case:
```
      \|/
   +- HEAD<---+
   |   |      |
   |  MID     |
   |   |      |
   +->LATCH --+
       |
      exit
```
It corresponds to a do-while loop with one if inside.

The patch achieves this by adding the `AdvancedUnroller` class. There are some redundancies with the `Unroller` class. It would probably be nice to get rid of these redundancies by maybe creating a class hierarchy and moving some parts of unrollers to an abstract class in the future.

Here's a testcase to show off this patch:
```cpp
int src()
{
    int x = 0;
    int i = 0;
    do
    {
        if (i % 2 == 0)
            x += 1;
        i += 1;
    } while (i < 10);
    return x;
}

int tgt()
{
    return 6;
}
```
With this patch applied, running `smtgcc-check-refine` on this code produces this:
```
testsmt3.c: In function ‘tgt’:
testsmt3.c:14:5: note: Transformation is not correct (retval)
src retval: #x00000005
tgt retval: #x00000006
   14 | int tgt()
      |
```
Without the patch, smtgcc gives up on the loop.